### PR TITLE
docs(guides): add vitest integration example

### DIFF
--- a/docs/guides/integration-examples/test-runners.md
+++ b/docs/guides/integration-examples/test-runners.md
@@ -165,6 +165,7 @@ export default defineConfig({
 
 ```ts
 import type { TestProject } from 'vitest/node';
+import { MongoMemoryServer } from 'mongodb-memory-server';
 
 declare module 'vitest' {
   export interface ProvidedContext {

--- a/docs/guides/integration-examples/test-runners.md
+++ b/docs/guides/integration-examples/test-runners.md
@@ -206,6 +206,10 @@ test('...', () => {
 });
 ```
 
+:::note
+Keep in mind that the global setup is running in a different global scope, so your tests don't have access to variables defined here. However, you can pass down serializable data to tests via [provide](https://vitest.dev/config/#provide) method as described above.
+:::
+
 See also [vitest-mms](https://github.com/danielpza/vitest-mms), which provides the `globalSetup` configuration among others helpers:
 
 ```ts

--- a/docs/guides/integration-examples/test-runners.md
+++ b/docs/guides/integration-examples/test-runners.md
@@ -145,6 +145,8 @@ Note that this tutorial is pre mongodb-memory-server 7.x.
 
 ## vitest
 
+<span class="badge badge--secondary">vitest version 3</span>
+
 For [vitest](https://vitest.dev/), create a [global setup file](https://vitest.dev/config/#globalsetup).
 
 `vitest.config.mts`:
@@ -204,4 +206,14 @@ test('...', () => {
 });
 ```
 
-See also [vitest-mms](https://github.com/danielpza/vitest-mms)
+See also [vitest-mms](https://github.com/danielpza/vitest-mms), which provides the `globalSetup` configuration among others helpers:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globalSetup: ['vitest-mms/globalSetup'],
+  },
+});
+```


### PR DESCRIPTION
Added [vitest](https://vitest.dev) integration example

Also linked to the https://github.com/danielpza/vitest-mms package which aims to make it easier to setup up mongodb-memory-server with vitest (DISCLAIMER: I'm the author of the package, I can drop it if that's an issue)