### PR TITLE
Update DryMongoBinary.ts

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
@@ -41,7 +41,7 @@ export interface DryMongoBinaryOptions extends BaseDryMongoBinaryOptions {
 export interface DryMongoBinaryNameOptions {
   version: NonNullable<DryMongoBinaryOptions['version']>;
   arch: NonNullable<DryMongoBinaryOptions['arch']>;
-  platform: NonNullable<DryMongoBinaryOptions['version']>;
+  platform: NonNullable<DryMongoBinaryOptions['platform']>;
   os: NonNullable<DryMongoBinaryOptions['os']>;
 }
 


### PR DESCRIPTION
I might miss something but why is the DryMongoBinaryOption for platform fed with 'version' instead of 'platform'?

## Related Issues
Potentially Typesupport issues in IDEs that use LSP