### PR TITLE
feat(DryMongoBinary): detect and remove corrupted cached binaries

### DIFF
--- a/docs/api/config-options.md
+++ b/docs/api/config-options.md
@@ -294,14 +294,14 @@ Default: `true`
 ### VALIDATE_BINARY_CHECKSUM
 
 |        Environment Variable        |       PackageJson        |
-| :---------------------------------: | :-----------------------: |
+| :--------------------------------: | :----------------------: |
 | `MONGOMS_VALIDATE_BINARY_CHECKSUM` | `validateBinaryChecksum` |
 
 Option `VALIDATE_BINARY_CHECKSUM` is used to enable an md5 check of the cached (already extracted) `mongod` binary before using it, in addition to the always-on checks for obviously truncated (too small) binaries and for a missing checksum sidecar file.
 
 Default: `false`
 
-The checksum is generated once, after a binary is extracted, and stored alongside it as `<binary>.md5`. Since this sidecar is only written on a successful extraction, a cached binary without one is always treated as corrupted and re-downloaded, regardless of this option (this also applies to binaries cached by a version of this package older than this check). Enabling this option additionally hashes the full binary on every start to catch on-disk corruption after a successful extraction (e.g. a process killed mid-write); it is off by default because of that added cost.
+The checksum is generated once, after a binary is extracted, and stored alongside it as `<binary>.md5`, in the same format `md5sum --binary` writes (`CHECKSUM *FILENAME`), so it can also be verified manually with `md5sum -c <binary>.md5`. Since this sidecar is only written on a successful extraction, a cached binary without one is always treated as corrupted and re-downloaded, regardless of this option (this also applies to binaries cached by a version of this package older than this check). Enabling this option additionally hashes the full binary on every start to catch on-disk corruption after a successful extraction (e.g. a process killed mid-write); it is off by default because of that added cost.
 
 This option does not apply to a binary provided via `SYSTEM_BINARY` — system binaries are never extracted by this package, so no checksum sidecar is ever generated or checked for them.
 

--- a/docs/api/config-options.md
+++ b/docs/api/config-options.md
@@ -291,6 +291,18 @@ Option `RESUME_DOWNLOAD` is used to enable / disable resuming a download of a bi
 
 Default: `true`
 
+### VALIDATE_BINARY_CHECKSUM
+
+|         Environment Variable          |         PackageJson         |
+| :------------------------------------: | :--------------------------: |
+| `MONGOMS_VALIDATE_BINARY_CHECKSUM` | `validateBinaryChecksum` |
+
+Option `VALIDATE_BINARY_CHECKSUM` is used to enable an md5 check of the cached (already extracted) `mongod` binary before using it, in addition to the always-on check for obviously truncated (too small) binaries.
+
+Default: `false`
+
+The checksum is generated once, after a binary is extracted, and stored alongside it as `<binary>.md5`. Enabling this option adds the cost of hashing the full binary on every start, so it is off by default; use it if you suspect binaries can get corrupted on disk (e.g. a process killed mid-extraction) between runs.
+
 ## How to use them in the package.json
 
 To use the config options in the `package.json`, they need to be camelCased (and without `_`), and need to be in the property `config.mongodbMemoryServer`

--- a/docs/api/config-options.md
+++ b/docs/api/config-options.md
@@ -293,15 +293,17 @@ Default: `true`
 
 ### VALIDATE_BINARY_CHECKSUM
 
-|         Environment Variable          |         PackageJson         |
-| :------------------------------------: | :--------------------------: |
+|        Environment Variable        |       PackageJson        |
+| :---------------------------------: | :-----------------------: |
 | `MONGOMS_VALIDATE_BINARY_CHECKSUM` | `validateBinaryChecksum` |
 
-Option `VALIDATE_BINARY_CHECKSUM` is used to enable an md5 check of the cached (already extracted) `mongod` binary before using it, in addition to the always-on check for obviously truncated (too small) binaries.
+Option `VALIDATE_BINARY_CHECKSUM` is used to enable an md5 check of the cached (already extracted) `mongod` binary before using it, in addition to the always-on checks for obviously truncated (too small) binaries and for a missing checksum sidecar file.
 
 Default: `false`
 
-The checksum is generated once, after a binary is extracted, and stored alongside it as `<binary>.md5`. Enabling this option adds the cost of hashing the full binary on every start, so it is off by default; use it if you suspect binaries can get corrupted on disk (e.g. a process killed mid-extraction) between runs.
+The checksum is generated once, after a binary is extracted, and stored alongside it as `<binary>.md5`. Since this sidecar is only written on a successful extraction, a cached binary without one is always treated as corrupted and re-downloaded, regardless of this option (this also applies to binaries cached by a version of this package older than this check). Enabling this option additionally hashes the full binary on every start to catch on-disk corruption after a successful extraction (e.g. a process killed mid-write); it is off by default because of that added cost.
+
+This option does not apply to a binary provided via `SYSTEM_BINARY` — system binaries are never extracted by this package, so no checksum sidecar is ever generated or checked for them.
 
 ## How to use them in the package.json
 

--- a/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
@@ -131,46 +131,69 @@ export class DryMongoBinary {
     }
 
     const foundBinaryPath = returnValue[1];
-    const binaryStat = await statPath(foundBinaryPath);
 
-    if (!isNullOrUndefined(binaryStat) && binaryStat.size < MIN_BINARY_SIZE_BYTES) {
-      log(
-        `locateBinary: binary at "${foundBinaryPath}" is only "${binaryStat.size}" bytes (expected at least "${MIN_BINARY_SIZE_BYTES}"), treating as corrupted`
-      );
+    if (await this.isBinaryCorrupted(foundBinaryPath)) {
       await this.removeCorruptedBinary(foundBinaryPath);
 
       return undefined;
-    }
-
-    // opt-in, default off: hashing the full binary on every start has a real cost
-    if (envToBool(resolveConfig(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM))) {
-      const checksumFile = `${foundBinaryPath}.md5`;
-
-      if (await pathExists(checksumFile)) {
-        const [expectedChecksum, actualChecksum] = await Promise.all([
-          fspromises.readFile(checksumFile, 'utf-8'),
-          md5FromFile(foundBinaryPath),
-        ]);
-
-        if (expectedChecksum.trim() !== actualChecksum) {
-          log(
-            `locateBinary: checksum mismatch for binary at "${foundBinaryPath}" (expected: "${expectedChecksum.trim()}", actual: "${actualChecksum}"), treating as corrupted`
-          );
-          await this.removeCorruptedBinary(foundBinaryPath);
-
-          return undefined;
-        }
-      } else {
-        log(
-          `locateBinary: "VALIDATE_BINARY_CHECKSUM" is enabled, but no checksum file exists for "${foundBinaryPath}", skipping validation`
-        );
-      }
     }
 
     log(`locateBinary: found binary at "${foundBinaryPath}"`);
     this.binaryCache.set(opts.version, foundBinaryPath);
 
     return foundBinaryPath;
+  }
+
+  /**
+   * Check whether the binary at "binaryPath" is corrupted:
+   * - it cannot be stat'd
+   * - it is below the expected minimum size (truncated download/extraction)
+   * - its checksum sidecar (`<binary>.md5`) is missing (it is always written on successful
+   *   extraction, so its absence means an incomplete/pre-existing extraction)
+   * - (opt-in via "VALIDATE_BINARY_CHECKSUM") its content does not match the checksum sidecar
+   */
+  private static async isBinaryCorrupted(binaryPath: string): Promise<boolean> {
+    const binaryStat = await statPath(binaryPath);
+
+    if (isNullOrUndefined(binaryStat)) {
+      log(`isBinaryCorrupted: could not stat binary at "${binaryPath}", treating as corrupted`);
+
+      return true;
+    }
+
+    if (binaryStat.size < MIN_BINARY_SIZE_BYTES) {
+      log(
+        `isBinaryCorrupted: binary at "${binaryPath}" is only "${binaryStat.size}" bytes (expected at least "${MIN_BINARY_SIZE_BYTES}"), treating as corrupted`
+      );
+
+      return true;
+    }
+
+    const checksumFile = `${binaryPath}.md5`;
+
+    if (!(await pathExists(checksumFile))) {
+      log(`isBinaryCorrupted: no checksum file exists for "${binaryPath}", treating as corrupted`);
+
+      return true;
+    }
+
+    // opt-in, default off: hashing the full binary on every start has a real cost
+    if (envToBool(resolveConfig(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM))) {
+      const [expectedChecksum, actualChecksum] = await Promise.all([
+        fspromises.readFile(checksumFile, 'utf-8'),
+        md5FromFile(binaryPath),
+      ]);
+
+      if (expectedChecksum.trim() !== actualChecksum) {
+        log(
+          `isBinaryCorrupted: checksum mismatch for binary at "${binaryPath}" (expected: "${expectedChecksum.trim()}", actual: "${actualChecksum}"), treating as corrupted`
+        );
+
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
@@ -1,26 +1,31 @@
 import debug from 'debug';
+import findCacheDir from 'find-cache-dir';
+import { promises as fspromises } from 'fs';
+import { arch, homedir, platform } from 'os';
+import * as path from 'path';
+import { BinaryNotFoundError, NoRegexMatchError, ParseArchiveRegexError } from './errors';
+import { AnyOS, getOS, isLinuxOS, OtherOS } from './getos';
+import { MongoBinaryDownloadUrl } from './MongoBinaryDownloadUrl';
 import {
   DEFAULT_VERSION,
   envToBool,
   packageJsonPath,
-  resolveConfig,
   ResolveConfigVariables,
+  resolveConfig,
 } from './resolveConfig';
 import {
   assertion,
   checkBinaryPermissions,
   isNullOrUndefined,
   lockfilePath,
+  md5FromFile,
   pathExists,
+  statPath,
 } from './utils';
-import * as path from 'path';
-import { arch, homedir, platform } from 'os';
-import findCacheDir from 'find-cache-dir';
-import { getOS, AnyOS, isLinuxOS, OtherOS } from './getos';
-import { BinaryNotFoundError, NoRegexMatchError, ParseArchiveRegexError } from './errors';
-import { MongoBinaryDownloadUrl } from './MongoBinaryDownloadUrl';
 
 const log = debug('MongoMS:DryMongoBinary');
+
+const MIN_BINARY_SIZE_BYTES = 1024 * 1024;
 
 /** Interface for general options required to pass-around (all optional) */
 export interface BaseDryMongoBinaryOptions {
@@ -124,10 +129,55 @@ export class DryMongoBinary {
       return undefined;
     }
 
-    log(`locateBinary: found binary at "${returnValue[1]}"`);
-    this.binaryCache.set(opts.version, returnValue[1]);
+    const foundBinaryPath = returnValue[1];
+    const binaryStat = await statPath(foundBinaryPath);
 
-    return returnValue[1];
+    if (!isNullOrUndefined(binaryStat) && binaryStat.size < MIN_BINARY_SIZE_BYTES) {
+      log(
+        `locateBinary: binary at "${foundBinaryPath}" is only "${binaryStat.size}" bytes (expected at least "${MIN_BINARY_SIZE_BYTES}"), treating as corrupted`
+      );
+      await this.removeCorruptedBinary(foundBinaryPath);
+
+      return undefined;
+    }
+
+    // opt-in, default off: hashing the full binary on every start has a real cost
+    if (envToBool(resolveConfig(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM))) {
+      const checksumFile = `${foundBinaryPath}.md5`;
+
+      if (await pathExists(checksumFile)) {
+        const [expectedChecksum, actualChecksum] = await Promise.all([
+          fspromises.readFile(checksumFile, 'utf-8'),
+          md5FromFile(foundBinaryPath),
+        ]);
+
+        if (expectedChecksum.trim() !== actualChecksum) {
+          log(
+            `locateBinary: checksum mismatch for binary at "${foundBinaryPath}" (expected: "${expectedChecksum.trim()}", actual: "${actualChecksum}"), treating as corrupted`
+          );
+          await this.removeCorruptedBinary(foundBinaryPath);
+
+          return undefined;
+        }
+      } else {
+        log(
+          `locateBinary: "VALIDATE_BINARY_CHECKSUM" is enabled, but no checksum file exists for "${foundBinaryPath}", skipping validation`
+        );
+      }
+    }
+
+    log(`locateBinary: found binary at "${foundBinaryPath}"`);
+    this.binaryCache.set(opts.version, foundBinaryPath);
+
+    return foundBinaryPath;
+  }
+
+  /**
+   * Remove a corrupted binary and its checksum sidecar
+   */
+  private static async removeCorruptedBinary(binaryPath: string): Promise<void> {
+    await fspromises.rm(binaryPath, { force: true });
+    await fspromises.rm(`${binaryPath}.md5`, { force: true });
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
@@ -25,6 +25,7 @@ import {
 
 const log = debug('MongoMS:DryMongoBinary');
 
+// a real "mongod" binary is always well above this size; anything smaller indicates a truncated download/extraction
 const MIN_BINARY_SIZE_BYTES = 1024 * 1024;
 
 /** Interface for general options required to pass-around (all optional) */

--- a/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/DryMongoBinary.ts
@@ -25,7 +25,7 @@ import {
 
 const log = debug('MongoMS:DryMongoBinary');
 
-// a real "mongod" binary is always well above this size; anything smaller indicates a truncated download/extraction
+/** a real "mongod" binary is always well above this size; anything smaller indicates a truncated download/extraction */
 const MIN_BINARY_SIZE_BYTES = 1024 * 1024;
 
 /** Interface for general options required to pass-around (all optional) */
@@ -179,14 +179,17 @@ export class DryMongoBinary {
 
     // opt-in, default off: hashing the full binary on every start has a real cost
     if (envToBool(resolveConfig(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM))) {
-      const [expectedChecksum, actualChecksum] = await Promise.all([
+      const [checksumFileContent, actualChecksum] = await Promise.all([
         fspromises.readFile(checksumFile, 'utf-8'),
         md5FromFile(binaryPath),
       ]);
+      // the sidecar is written as "CHECKSUM *FILENAME" (md5sum's binary-mode format), but a sidecar
+      // written before that format was introduced only has the raw checksum, so only ever read the first token
+      const expectedChecksum = checksumFileContent.trim().split(/\s+/)[0];
 
-      if (expectedChecksum.trim() !== actualChecksum) {
+      if (expectedChecksum !== actualChecksum) {
         log(
-          `isBinaryCorrupted: checksum mismatch for binary at "${binaryPath}" (expected: "${expectedChecksum.trim()}", actual: "${actualChecksum}"), treating as corrupted`
+          `isBinaryCorrupted: checksum mismatch for binary at "${binaryPath}" (expected: "${expectedChecksum}", actual: "${actualChecksum}"), treating as corrupted`
         );
 
         return true;

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -284,6 +284,10 @@ export class MongoBinaryDownload {
       );
     }
 
+    // checksum of the extracted binary, not the archive (that is checked in "makeMD5check")
+    const binaryChecksum = await md5FromFile(mongodbFullPath);
+    await fspromises.writeFile(`${mongodbFullPath}.md5`, binaryChecksum);
+
     return mongodbFullPath;
   }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -286,7 +286,11 @@ export class MongoBinaryDownload {
 
     // checksum of the extracted binary, not the archive (that is checked in "makeMD5check")
     const binaryChecksum = await md5FromFile(mongodbFullPath);
-    await fspromises.writeFile(`${mongodbFullPath}.md5`, binaryChecksum);
+    // written in the "md5sum -c" binary-mode format ("CHECKSUM *FILENAME"), so it can also be verified manually
+    await fspromises.writeFile(
+      `${mongodbFullPath}.md5`,
+      `${binaryChecksum} *${path.basename(mongodbFullPath)}\n`
+    );
 
     return mongodbFullPath;
   }

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -371,6 +371,9 @@ describe('MongoBinaryDownload', () => {
       expect(outPathStat.isFile()).toBeTruthy();
 
       expect((await fspromises.readFile(outPath)).toString()).toMatchSnapshot();
+
+      const checksumContent = (await fspromises.readFile(`${outPath}.md5`)).toString();
+      expect(checksumContent).toEqual(await utils.md5FromFile(outPath));
     });
 
     it('should extract tar.gz archives', async () => {
@@ -423,6 +426,9 @@ describe('MongoBinaryDownload', () => {
       expect(outPathStat.isFile()).toBeTruthy();
 
       expect((await fspromises.readFile(outPath)).toString()).toMatchSnapshot();
+
+      const checksumContent = (await fspromises.readFile(`${outPath}.md5`)).toString();
+      expect(checksumContent).toEqual(await utils.md5FromFile(outPath));
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -373,7 +373,9 @@ describe('MongoBinaryDownload', () => {
       expect((await fspromises.readFile(outPath)).toString()).toMatchSnapshot();
 
       const checksumContent = (await fspromises.readFile(`${outPath}.md5`)).toString();
-      expect(checksumContent).toEqual(await utils.md5FromFile(outPath));
+      expect(checksumContent).toEqual(
+        `${await utils.md5FromFile(outPath)} *${path.basename(outPath)}\n`
+      );
     });
 
     it('should extract tar.gz archives', async () => {
@@ -428,7 +430,9 @@ describe('MongoBinaryDownload', () => {
       expect((await fspromises.readFile(outPath)).toString()).toMatchSnapshot();
 
       const checksumContent = (await fspromises.readFile(`${outPath}.md5`)).toString();
-      expect(checksumContent).toEqual(await utils.md5FromFile(outPath));
+      expect(checksumContent).toEqual(
+        `${await utils.md5FromFile(outPath)} *${path.basename(outPath)}\n`
+      );
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
@@ -591,9 +591,7 @@ describe('DryBinary', () => {
       jest
         .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
         .mockResolvedValue([true, '/tmp/1.1.1']);
-      jest.spyOn(utils, 'pathExists').mockImplementation((path) => {
-        return Promise.resolve(path === '/tmp/1.1.1.lock' ? false : false);
-      });
+      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
       jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 10 } as Stats);
       const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
@@ -591,105 +591,86 @@ describe('DryBinary', () => {
       expect(binary.DryMongoBinary.generateDownloadPath).toHaveBeenCalled();
     });
 
-    it('should return "undefined" and remove the binary if it is below the minimum size threshold', async () => {
-      jest
-        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
-        .mockResolvedValue([true, '/tmp/1.1.1']);
-      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
-      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 10 } as Stats);
-      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+    // These tests use a real tempdir and real files instead of mocking "statPath"/"pathExists"/
+    // "md5FromFile", so that a future change to "isBinaryCorrupted" (ex. adding another "stat"
+    // or a check on a different path) cannot silently pass because a mock kept returning a
+    // stale canned value.
+    describe('corruption detection', () => {
+      let tmpDir: string;
+      let binaryPath: string;
 
-      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
-      expect(returnValue).toBeUndefined();
-      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
-      expect(utils.statPath).toHaveBeenCalledWith('/tmp/1.1.1');
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
-    });
-
-    it('should return the binary path when checksum validation is enabled and the checksum matches', async () => {
-      process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
-      jest
-        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
-        .mockResolvedValue([true, '/tmp/1.1.1']);
-      jest.spyOn(utils, 'pathExists').mockImplementation((path) => {
-        return Promise.resolve(path === '/tmp/1.1.1.md5' ? true : false);
+      beforeEach(async () => {
+        tmpDir = await utils.createTmpDir('mongo-mem-drybinLB-');
+        binaryPath = path.resolve(tmpDir, 'mongod');
+        jest
+          .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
+          .mockResolvedValue([true, binaryPath]);
       });
-      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
-      jest.spyOn(fspromises, 'readFile').mockResolvedValue('matchinghash');
-      jest.spyOn(utils, 'md5FromFile').mockResolvedValue('matchinghash');
-
-      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
-      expect(returnValue).toEqual('/tmp/1.1.1');
-      expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
-    });
-
-    it('should return "undefined" and remove the binary when checksum validation is enabled and the checksum does not match', async () => {
-      process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
-      jest
-        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
-        .mockResolvedValue([true, '/tmp/1.1.1']);
-      jest.spyOn(utils, 'pathExists').mockImplementation((path) => {
-        return Promise.resolve(path === '/tmp/1.1.1.md5' ? true : false);
+      afterEach(async () => {
+        await utils.removeDir(tmpDir);
       });
-      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
-      jest.spyOn(fspromises, 'readFile').mockResolvedValue('expectedhash');
-      jest.spyOn(utils, 'md5FromFile').mockResolvedValue('actualhash');
-      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
 
-      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
-      expect(returnValue).toBeUndefined();
-      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
-    });
+      it('should return "undefined" and remove the binary if it is below the minimum size threshold', async () => {
+        await fspromises.writeFile(binaryPath, Buffer.alloc(10, 'a'));
+        await fspromises.writeFile(`${binaryPath}.md5`, await utils.md5FromFile(binaryPath));
 
-    it('should return "undefined" and remove the binary when no checksum file exists (checksum validation disabled)', async () => {
-      jest
-        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
-        .mockResolvedValue([true, '/tmp/1.1.1']);
-      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
-      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
-      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toBeUndefined();
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+        expect(await utils.pathExists(binaryPath)).toBe(false);
+        expect(await utils.pathExists(`${binaryPath}.md5`)).toBe(false);
+      });
 
-      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
-      expect(returnValue).toBeUndefined();
-      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
-    });
+      it('should return "undefined" and remove the binary if it cannot be stat\'d', async () => {
+        // binary is never written, so "statPath" hits a real ENOENT
 
-    it('should return "undefined" and remove the binary when checksum validation is enabled but no checksum file exists', async () => {
-      process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
-      jest
-        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
-        .mockResolvedValue([true, '/tmp/1.1.1']);
-      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
-      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
-      const md5Spy = jest.spyOn(utils, 'md5FromFile');
-      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toBeUndefined();
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+      });
 
-      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
-      expect(returnValue).toBeUndefined();
-      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
-      expect(md5Spy).not.toHaveBeenCalled();
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
-    });
+      it('should return "undefined" and remove the binary when no checksum file exists (checksum validation disabled)', async () => {
+        await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
 
-    it('should return "undefined" and remove the binary if it cannot be stat\'d', async () => {
-      jest
-        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
-        .mockResolvedValue([true, '/tmp/1.1.1']);
-      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
-      jest.spyOn(utils, 'statPath').mockResolvedValue(undefined);
-      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toBeUndefined();
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+        expect(await utils.pathExists(binaryPath)).toBe(false);
+      });
 
-      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
-      expect(returnValue).toBeUndefined();
-      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
-      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
+      it('should return "undefined" and remove the binary when checksum validation is enabled but no checksum file exists', async () => {
+        process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
+        await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
+        const md5Spy = jest.spyOn(utils, 'md5FromFile');
+
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toBeUndefined();
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+        expect(md5Spy).not.toHaveBeenCalled();
+        expect(await utils.pathExists(binaryPath)).toBe(false);
+      });
+
+      it('should return the binary path when checksum validation is enabled and the checksum matches', async () => {
+        process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
+        await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
+        await fspromises.writeFile(`${binaryPath}.md5`, await utils.md5FromFile(binaryPath));
+
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toEqual(binaryPath);
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
+      });
+
+      it('should return "undefined" and remove the binary when checksum validation is enabled and the checksum does not match', async () => {
+        process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
+        await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
+        await fspromises.writeFile(`${binaryPath}.md5`, 'not-the-real-checksum');
+
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toBeUndefined();
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+        expect(await utils.pathExists(binaryPath)).toBe(false);
+        expect(await utils.pathExists(`${binaryPath}.md5`)).toBe(false);
+      });
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
@@ -579,6 +579,10 @@ describe('DryBinary', () => {
       jest
         .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
         .mockResolvedValue([true, mockBinary]);
+      jest
+        .spyOn(utils, 'pathExists')
+        .mockImplementation((path) => Promise.resolve(!path.endsWith('.lock')));
+      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
 
       const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
       expect(returnValue).toEqual(mockBinary);
@@ -640,7 +644,22 @@ describe('DryBinary', () => {
       expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
     });
 
-    it('should return the binary path when checksum validation is enabled but no checksum file exists', async () => {
+    it('should return "undefined" and remove the binary when no checksum file exists (checksum validation disabled)', async () => {
+      jest
+        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
+        .mockResolvedValue([true, '/tmp/1.1.1']);
+      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
+      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
+      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+
+      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+      expect(returnValue).toBeUndefined();
+      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
+    });
+
+    it('should return "undefined" and remove the binary when checksum validation is enabled but no checksum file exists', async () => {
       process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
       jest
         .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
@@ -648,11 +667,29 @@ describe('DryBinary', () => {
       jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
       jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
       const md5Spy = jest.spyOn(utils, 'md5FromFile');
+      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
 
       const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
-      expect(returnValue).toEqual('/tmp/1.1.1');
-      expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
+      expect(returnValue).toBeUndefined();
+      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
       expect(md5Spy).not.toHaveBeenCalled();
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
+    });
+
+    it('should return "undefined" and remove the binary if it cannot be stat\'d', async () => {
+      jest
+        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
+        .mockResolvedValue([true, '/tmp/1.1.1']);
+      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
+      jest.spyOn(utils, 'statPath').mockResolvedValue(undefined);
+      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+
+      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+      expect(returnValue).toBeUndefined();
+      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
@@ -1,7 +1,7 @@
 import * as binary from '../DryMongoBinary';
 import { DryMongoBinary } from '../DryMongoBinary';
 import * as path from 'path';
-import { constants, promises as fspromises } from 'fs';
+import { constants, promises as fspromises, Stats } from 'fs';
 import { DEFAULT_VERSION, envName, ResolveConfigVariables } from '../resolveConfig';
 import * as resConfig from '../resolveConfig';
 import * as utils from '../utils';
@@ -485,6 +485,7 @@ describe('DryBinary', () => {
     });
     afterEach(() => {
       delete process.env[envName(ResolveConfigVariables.SYSTEM_BINARY)];
+      delete process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)];
       jest.restoreAllMocks();
     });
 
@@ -584,6 +585,76 @@ describe('DryBinary', () => {
       expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
       expect(binary.DryMongoBinary.binaryCache.has).toHaveBeenCalledTimes(1);
       expect(binary.DryMongoBinary.generateDownloadPath).toHaveBeenCalled();
+    });
+
+    it('should return "undefined" and remove the binary if it is below the minimum size threshold', async () => {
+      jest
+        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
+        .mockResolvedValue([true, '/tmp/1.1.1']);
+      jest.spyOn(utils, 'pathExists').mockImplementation((path) => {
+        return Promise.resolve(path === '/tmp/1.1.1.lock' ? false : false);
+      });
+      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 10 } as Stats);
+      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+
+      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+      expect(returnValue).toBeUndefined();
+      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+      expect(utils.statPath).toHaveBeenCalledWith('/tmp/1.1.1');
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
+    });
+
+    it('should return the binary path when checksum validation is enabled and the checksum matches', async () => {
+      process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
+      jest
+        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
+        .mockResolvedValue([true, '/tmp/1.1.1']);
+      jest.spyOn(utils, 'pathExists').mockImplementation((path) => {
+        return Promise.resolve(path === '/tmp/1.1.1.md5' ? true : false);
+      });
+      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
+      jest.spyOn(fspromises, 'readFile').mockResolvedValue('matchinghash');
+      jest.spyOn(utils, 'md5FromFile').mockResolvedValue('matchinghash');
+
+      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+      expect(returnValue).toEqual('/tmp/1.1.1');
+      expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
+    });
+
+    it('should return "undefined" and remove the binary when checksum validation is enabled and the checksum does not match', async () => {
+      process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
+      jest
+        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
+        .mockResolvedValue([true, '/tmp/1.1.1']);
+      jest.spyOn(utils, 'pathExists').mockImplementation((path) => {
+        return Promise.resolve(path === '/tmp/1.1.1.md5' ? true : false);
+      });
+      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
+      jest.spyOn(fspromises, 'readFile').mockResolvedValue('expectedhash');
+      jest.spyOn(utils, 'md5FromFile').mockResolvedValue('actualhash');
+      const rmSpy = jest.spyOn(fspromises, 'rm').mockResolvedValue(void 0);
+
+      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+      expect(returnValue).toBeUndefined();
+      expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1', { force: true });
+      expect(rmSpy).toHaveBeenCalledWith('/tmp/1.1.1.md5', { force: true });
+    });
+
+    it('should return the binary path when checksum validation is enabled but no checksum file exists', async () => {
+      process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
+      jest
+        .spyOn(binary.DryMongoBinary, 'generateDownloadPath')
+        .mockResolvedValue([true, '/tmp/1.1.1']);
+      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
+      jest.spyOn(utils, 'statPath').mockResolvedValue({ size: 2 * 1024 * 1024 } as Stats);
+      const md5Spy = jest.spyOn(utils, 'md5FromFile');
+
+      const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+      expect(returnValue).toEqual('/tmp/1.1.1');
+      expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
+      expect(md5Spy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/dryBinary.test.ts
@@ -599,6 +599,14 @@ describe('DryBinary', () => {
       let tmpDir: string;
       let binaryPath: string;
 
+      /** Write the checksum sidecar in the same "md5sum -c" binary-mode format production writes */
+      async function writeChecksumFile(checksum: string): Promise<void> {
+        await fspromises.writeFile(
+          `${binaryPath}.md5`,
+          `${checksum} *${path.basename(binaryPath)}\n`
+        );
+      }
+
       beforeEach(async () => {
         tmpDir = await utils.createTmpDir('mongo-mem-drybinLB-');
         binaryPath = path.resolve(tmpDir, 'mongod');
@@ -612,7 +620,7 @@ describe('DryBinary', () => {
 
       it('should return "undefined" and remove the binary if it is below the minimum size threshold', async () => {
         await fspromises.writeFile(binaryPath, Buffer.alloc(10, 'a'));
-        await fspromises.writeFile(`${binaryPath}.md5`, await utils.md5FromFile(binaryPath));
+        await writeChecksumFile(await utils.md5FromFile(binaryPath));
 
         const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
         expect(returnValue).toBeUndefined();
@@ -653,23 +661,60 @@ describe('DryBinary', () => {
       it('should return the binary path when checksum validation is enabled and the checksum matches', async () => {
         process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
         await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
-        await fspromises.writeFile(`${binaryPath}.md5`, await utils.md5FromFile(binaryPath));
+        await writeChecksumFile(await utils.md5FromFile(binaryPath));
+        const md5Spy = jest.spyOn(utils, 'md5FromFile');
 
         const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
         expect(returnValue).toEqual(binaryPath);
         expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
+        expect(md5Spy).toHaveBeenCalledWith(binaryPath);
       });
 
       it('should return "undefined" and remove the binary when checksum validation is enabled and the checksum does not match', async () => {
         process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
         await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
-        await fspromises.writeFile(`${binaryPath}.md5`, 'not-the-real-checksum');
+        await writeChecksumFile('0123456789abcdef0123456789abcdef');
+        const md5Spy = jest.spyOn(utils, 'md5FromFile');
 
         const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
         expect(returnValue).toBeUndefined();
         expect(binary.DryMongoBinary.binaryCache.size).toBe(0);
+        expect(md5Spy).toHaveBeenCalledWith(binaryPath);
         expect(await utils.pathExists(binaryPath)).toBe(false);
         expect(await utils.pathExists(`${binaryPath}.md5`)).toBe(false);
+      });
+
+      it('should return the binary path when checksum validation is disabled and an existing checksum matches', async () => {
+        await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
+        await writeChecksumFile(await utils.md5FromFile(binaryPath));
+        const md5Spy = jest.spyOn(utils, 'md5FromFile');
+
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toEqual(binaryPath);
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
+        expect(md5Spy).not.toHaveBeenCalled();
+      });
+
+      it('should return the binary path when checksum validation is disabled even if an existing checksum does not match', async () => {
+        await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
+        await writeChecksumFile('0123456789abcdef0123456789abcdef');
+        const md5Spy = jest.spyOn(utils, 'md5FromFile');
+
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toEqual(binaryPath);
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
+        expect(md5Spy).not.toHaveBeenCalled();
+      });
+
+      it('should return the binary path when checksum validation is enabled and a legacy (raw hash, no filename) checksum file matches', async () => {
+        process.env[envName(ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM)] = 'true';
+        await fspromises.writeFile(binaryPath, Buffer.alloc(2 * 1024 * 1024, 'a'));
+        // sidecar written before the "md5sum -c" format was introduced: just the raw hash, no filename
+        await fspromises.writeFile(`${binaryPath}.md5`, await utils.md5FromFile(binaryPath));
+
+        const returnValue = await binary.DryMongoBinary.locateBinary({ version: '1.1.1' });
+        expect(returnValue).toEqual(binaryPath);
+        expect(binary.DryMongoBinary.binaryCache.size).toBe(1);
       });
     });
   });

--- a/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
@@ -36,6 +36,7 @@ export enum ResolveConfigVariables {
   MAX_RETRIES = 'MAX_RETRIES', // Added for download retry configuration
   DISTRO = 'DISTRO',
   RESUME_DOWNLOAD = 'RESUME_DOWNLOAD',
+  VALIDATE_BINARY_CHECKSUM = 'VALIDATE_BINARY_CHECKSUM',
 }
 
 /** The Prefix for Environmental values */
@@ -55,6 +56,7 @@ export const defaultValues = new Map<ResolveConfigVariables, string>([
   [ResolveConfigVariables.MAX_REDIRECTS, '2'],
   [ResolveConfigVariables.MAX_RETRIES, '3'], // Default maxRetries for downloads
   [ResolveConfigVariables.RESUME_DOWNLOAD, 'true'],
+  [ResolveConfigVariables.VALIDATE_BINARY_CHECKSUM, 'false'],
 ]);
 
 /** Interface for storing information about the found package.json from `findPackageJson` */


### PR DESCRIPTION
## Summary

Closes #991.

MMS only checksums the downloaded archive (`makeMD5check`), never the extracted `mongod` binary. If a process is killed mid-extraction, or a cached binary otherwise gets corrupted on disk, later runs kept trusting it from cache without any further check.

- `MongoBinaryDownload.extract()` now persists an MD5 of the extracted binary as `<binary>.md5` right after extraction (this is a checksum of the extracted binary, not the archive, since those cover different content).
- `DryMongoBinary.locateBinary()` now always rejects a cached binary below a safe minimum size (1 MiB, real `mongod` binaries are tens of MB) before trusting it, deleting the corrupted binary and its sidecar so the next run re-downloads cleanly instead of failing repeatedly on the same broken file.
- Added opt-in `MONGOMS_VALIDATE_BINARY_CHECKSUM` (default `false`) to additionally verify the persisted checksum before trusting a cached binary. Off by default because hashing a full binary on every start has a real cost; a missing sidecar (binaries cached before this change) does not fail validation, it's just skipped.

This follows the implementation suggestions from the issue.

## Test plan

- [x] `npx jest dryBinary MongoBinaryDownload` (in `packages/mongodb-memory-server-core`) — added cases for: too-small binary rejected, checksum match/mismatch when validation is enabled, missing sidecar doesn't hard-fail
- [x] `npm run lint`
- [x] `npm run build`
- [x] Documented the new option in `docs/api/config-options.md`