### PR TITLE
chore(CODEOWNERS): remove nodkz from anything other than license

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,4 @@
 # Top Level; Everything that is not convered by anything below
-* @nodkz @hasezoey
+* @hasezoey
 
-**/LICENSE.md @nodkz
-website/ @hasezoey
-docs/ @hasezoey @nodkz
-.github/ @hasezoey @nodkz
+**/LICENSE.md @hasezoey @nodkz


### PR DESCRIPTION
This is simply due to nodkz practically not being a maintainer anymore and so does not need to be tagged on every PR. (see [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners))

@nodkz What do you think about this?

Note that i will likely just merge this if i dont get a response until 2027.